### PR TITLE
Remove --use-mirrors from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install pep8 --use-mirrors
+  - pip install pep8
 script:
   - pep8 --exclude=lib,vendor.py,appengine_config.py .


### PR DESCRIPTION
pip option "--use-mirrors" is now deprecated, which causes failures in Travis tests
pypa/pip#1098